### PR TITLE
Fix write_output=False bug

### DIFF
--- a/im2deep/__init__.py
+++ b/im2deep/__init__.py
@@ -1,3 +1,3 @@
 """IM2Deep: Deep learning framework for peptide collisional cross section prediction."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"


### PR DESCRIPTION
This pull request includes several updates to the `predict_ccs` function in the `im2deep` module and a version bump for the package. The changes focus on improving the handling of output files and logging, as well as ensuring proper conversion and prediction of ion mobility values, and fixes a bug to ensure that the predicted CCS/IM column is correctly returned when write_output is set to False