### PR TITLE
Fix calibration logic by removing error and multiconformer output in csv

### DIFF
--- a/im2deep/_io_helpers.py
+++ b/im2deep/_io_helpers.py
@@ -210,7 +210,6 @@ def _parse_legacy_format(input_file: str | Path) -> PSMList:
             if has_ccs:
                 metadata = {"CCS": _normalize_ccs_metadata_value(row["CCS"])}
 
-            LOGGER.debug(f"Parsed PSM: {peptidoform} with metadata: {metadata}")
             precursor = PSM(peptidoform=peptidoform, metadata=metadata, spectrum_id=idx)
             list_of_precursors.append(precursor)
         except Exception as e:
@@ -402,20 +401,40 @@ def write_output(
     ion_mobility : bool, optional
         Whether to include ion mobility in the output. Default is False.
     """
+    is_multi = len(predictions) > 0 and isinstance(predictions[0], np.ndarray)
     output_data = []
     for idx, psm in enumerate(psm_list):
-        entry = {
-            "index": psm.spectrum_id,
-            "peptidoform": str(psm.peptidoform),
-            "predicted_CCS": predictions[idx],
-        }
-        if ion_mobility:
-            im_value = ccs2im(
-                predictions[idx],
-                psm.peptidoform.theoretical_mz,  # type: ignore -  already checked charge present
-                psm.peptidoform.precursor_charge,  # type: ignore -  already checked charge present
-            )
-            entry["predicted_ion_mobility"] = im_value
+        if is_multi:
+            ccs_low, ccs_high = sorted(predictions[idx])
+            entry = {
+                "index": psm.spectrum_id,
+                "peptidoform": str(psm.peptidoform),
+                "predicted_ccs_low": ccs_low,
+                "predicted_ccs_high": ccs_high,
+            }
+            if ion_mobility:
+                entry["predicted_ion_mobility_low"] = ccs2im(
+                    ccs_low,
+                    psm.peptidoform.theoretical_mz,  # type: ignore -  already checked charge present
+                    psm.peptidoform.precursor_charge,  # type: ignore -  already checked charge present
+                )
+                entry["predicted_ion_mobility_high"] = ccs2im(
+                    ccs_high,
+                    psm.peptidoform.theoretical_mz,  # type: ignore -  already checked charge present
+                    psm.peptidoform.precursor_charge,  # type: ignore -  already checked charge present
+                )
+        else:
+            entry = {
+                "index": psm.spectrum_id,
+                "peptidoform": str(psm.peptidoform),
+                "predicted_CCS": predictions[idx],
+            }
+            if ion_mobility:
+                entry["predicted_ion_mobility"] = ccs2im(
+                    predictions[idx],
+                    psm.peptidoform.theoretical_mz,  # type: ignore -  already checked charge present
+                    psm.peptidoform.precursor_charge,  # type: ignore -  already checked charge present
+                )
         output_data.append(entry)
 
     output_df = pd.DataFrame(output_data)

--- a/im2deep/calibration.py
+++ b/im2deep/calibration.py
@@ -440,6 +440,10 @@ class LinearCCSCalibration(Calibration):
             target_work["CCS"] = target_work["metadata"].apply(
                 lambda x: float(x["CCS"]) if isinstance(x, dict) and "CCS" in x else np.nan
             )
+        if "CCS" not in source_work.columns and "metadata" in source_work.columns:
+            source_work["CCS"] = source_work["metadata"].apply(
+                lambda x: float(x["CCS"]) if isinstance(x, dict) and "CCS" in x else np.nan
+            )
 
         source_work["peptide_key"] = source_work["peptidoform"].apply(get_peptide_key)
         source_work["charge"] = source_work["peptidoform"].apply(get_charge)

--- a/im2deep/core.py
+++ b/im2deep/core.py
@@ -128,7 +128,6 @@ def predict_and_calibrate(
         )
 
     if not calibration.is_fitted:
-        calibration_reference = psm_df_reference if psm_df_reference is not None else psm_df_cal
         LOGGER.info("Fitting calibration...")
         if any(psm_list_cal["is_decoy"]):
             LOGGER.warning(
@@ -137,7 +136,7 @@ def predict_and_calibrate(
             )
         calibration.fit(
             psm_df_cal,
-            calibration_reference,
+            psm_df_reference,  # None is fine; fit() loads the default reference if needed
             multi=multi,
         )
     else:


### PR DESCRIPTION

### Changed
- Updated `write_output` in `im2deep/_io_helpers.py` to handle multi-output predictions, enabling output of both low and high CCS predictions together with their corresponding ion mobility values.
- Improved CCS metadata extraction in `im2deep/calibration.py` by populating the CCS column from metadata when it is absent from the source DataFrame.
- Simplified calibration fitting in `im2deep/core.py` by passing `psm_df_reference` directly to `fit()`, allowing the method to resolve `None` values and load the default reference internally.
- Removed redundant assignment of `calibration_reference` during calibration fitting in `im2deep/core.py` to streamline the logic.

### Removed
- Removed an unnecessary debug logging statement from the legacy format parser in `im2deep/_io_helpers.py` to reduce log verbosity.