### PR TITLE
Add Sphinx documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+  commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv sync --group docs
+    - uv run python -m sphinx -T -b dirhtml docs/source $READTHEDOCS_OUTPUT/html

--- a/README.md
+++ b/README.md
@@ -7,14 +7,23 @@ Collisional cross-section prediction for (modified) peptides.
 IM2Deep is a deep learning-based CCS predictor for (modified) peptides. It accurately predicts collisional cross-section (CCS) values for modified peptides, even if the modification wasn't observed during training. The tool supports both single-conformer and multi-conformer predictions for peptide ions.
 
 ## Installation
-Install with pip:
+
+With Python 3.11 or higher, install with pip:
 
 ```bash
 pip install im2deep
 ```
 
-For local development/docs:
+We recommend using a [venv](https://docs.python.org/3/library/venv.html) or
+[conda](https://docs.conda.io/en/latest/) virtual environment.
+
+### For development
+
+Clone this repository and use [uv](https://docs.astral.sh/uv/) to install:
+
 ```bash
+git clone https://github.com/CompOmics/IM2Deep.git
+cd IM2Deep
 uv sync --group dev --group docs
 ```
 
@@ -113,7 +122,7 @@ IPQEKCILQTDVK,5|Butyryl|6|Carbamidomethyl,3,516.2079366048176
 - **Charge states**: IM2Deep predictions are reliable for charge states up to z=6. PSMs with higher charge states are automatically filtered out during validation.
 
 ## Citing
-If you use IM2Deep within the context of [(TI)MS<sup>2</sup>Rescore](https://github.com/compomics/ms2rescore), please cite the following:
+If you use IM2Deep within the context of [(TI)MS²Rescore](https://github.com/compomics/ms2rescore), please cite the following:
 > **TIMS²Rescore: A DDA-PASEF optimized data-driven rescoring pipeline based on MS²Rescore.**
 > Arthur Declercq*, Robbe Devreese*, Jonas Scheid, Caroline Jachmann, Tim Van Den Bossche, Annica Preikschat, David Gomez-Zepeda, Jeewan Babu Rijal, Aurélie Hirschler, Jonathan R Krieger, Tharan Srikumar, George Rosenberger, Dennis Trede, Christine Carapito, Stefan Tenzer, Juliane S Walz, Sven Degroeve, Robbin Bouwmeester, Lennart Martens, and Ralf Gabriels.
 > _Journal of Proteome Research_ (2025) [doi:10.1021/acs.jproteome.4c00609](https://doi.org/10.1021/acs.jproteome.4c00609) <span class="__dimensions_badge_embed__" data-doi="10.1021/acs.jproteome.4c00609" data-hide-zero-citations="true" data-style="small_rectangle"></span>

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,0 +1,13 @@
+/* Replace the copyright with license info */
+div[role=contentinfo] {
+    visibility: hidden;
+    position: relative;
+}
+
+div[role=contentinfo]:after {
+    visibility: visible;
+    position: absolute;
+    top: 0;
+    left: 0;
+    content: "Apache License 2.0";
+}

--- a/docs/source/api/im2deep.calibration.rst
+++ b/docs/source/api/im2deep.calibration.rst
@@ -1,0 +1,6 @@
+*******************
+im2deep.calibration
+*******************
+
+.. automodule:: im2deep.calibration
+   :members:

--- a/docs/source/api/im2deep.core.rst
+++ b/docs/source/api/im2deep.core.rst
@@ -1,0 +1,6 @@
+************
+im2deep.core
+************
+
+.. automodule:: im2deep.core
+   :members:

--- a/docs/source/api/im2deep.exceptions.rst
+++ b/docs/source/api/im2deep.exceptions.rst
@@ -1,0 +1,6 @@
+******************
+im2deep.exceptions
+******************
+
+.. automodule:: im2deep.exceptions
+   :members:

--- a/docs/source/api/im2deep.rst
+++ b/docs/source/api/im2deep.rst
@@ -1,0 +1,8 @@
+*******
+im2deep
+*******
+
+.. automodule:: im2deep
+   :members:
+   :undoc-members:
+   :imported-members:

--- a/docs/source/api/im2deep.utils.rst
+++ b/docs/source/api/im2deep.utils.rst
@@ -1,0 +1,6 @@
+*************
+im2deep.utils
+*************
+
+.. automodule:: im2deep.utils
+   :members:

--- a/docs/source/cli/cli.rst
+++ b/docs/source/cli/cli.rst
@@ -1,0 +1,7 @@
+**********************
+Command line interface
+**********************
+
+.. click:: im2deep.__main__:cli
+   :prog: im2deep
+   :nested: full

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,57 @@
+"""Configuration file for the Sphinx documentation builder."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../"))
+
+from im2deep import __version__
+
+# Project information
+project = "im2deep"
+author = "CompOmics"
+github_project_url = "https://github.com/CompOmics/IM2Deep/"
+github_doc_root = "https://github.com/CompOmics/IM2Deep/tree/main/docs/"
+
+# Version
+release = __version__
+
+# General configuration
+extensions = [
+    "sphinx.ext.autodoc",
+    # "sphinx.ext.autosectionlabel",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "sphinx_click.ext",
+    "sphinx_rtd_theme",
+    "sphinx_mdinclude",
+]
+source_suffix = [".rst", ".md"]
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+# Options for HTML output
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+html_css_files = ["css/custom.css"]
+
+# Autodoc options
+autodoc_default_options = {"members": True, "show-inheritance": True}
+autodoc_member_order = "bysource"
+autodoc_typehints = "description"
+autoclass_content = "init"
+
+# Intersphinx options
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "psm_utils": ("https://psm-utils.readthedocs.io/en/stable/", None),
+    "torch": ("https://docs.pytorch.org/docs/stable/", None),
+}
+
+# Napoleon options
+napoleon_numpy_docstring = True
+napoleon_google_docstring = False

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,30 @@
+.. mdinclude:: ../../README.md
+
+
+.. toctree::
+   :caption: About
+   :hidden:
+   :includehidden:
+   :maxdepth: 2
+
+   Home <self>
+
+
+.. toctree::
+   :caption: Command line interface
+   :hidden:
+   :includehidden:
+   :glob:
+   :maxdepth: 2
+
+   cli/*
+
+
+.. toctree::
+   :caption: Python API reference
+   :hidden:
+   :includehidden:
+   :glob:
+   :maxdepth: 2
+
+   api/*

--- a/im2deep/utils.py
+++ b/im2deep/utils.py
@@ -37,7 +37,7 @@ def im2ccs(
     temp: float = TEMP,
     t_diff: float = T_DIFF,
 ) -> float | np.ndarray:
-    """
+    r"""
     Convert reduced ion mobility to collisional cross section.
 
     This function converts reduced ion mobility (1/K0) values to collisional
@@ -67,18 +67,18 @@ def im2ccs(
     Notes
     -----
     The conversion uses the Mason-Schamp equation:
-    CCS = (18509.8632163405 * z) / (sqrt(μ * T) * K0)
 
-    Where:
-    - z is the charge
-    - μ is the reduced mass
-    - T is temperature in Kelvin
-    - K0 is the ion mobility
+    .. math::
+
+        \Omega = \frac{C \cdot z}{\sqrt{\mu \cdot T} \cdot K_0}
+
+    where :math:`\Omega` is the CCS, :math:`C` is a summary constant (18509.8632163405),
+    :math:`z` is the charge, :math:`\mu` is the reduced mass, :math:`T` is the temperature
+    in Kelvin, and :math:`K_0` is the reduced ion mobility.
 
     References
     ----------
-    Adapted from theGreatHerrLebert/ionmob
-    (https://doi.org/10.1093/bioinformatics/btad486)
+    Adapted from `theGreatHerrLebert/ionmob <https://doi.org/10.1093/bioinformatics/btad486>`_.
 
     Examples
     --------
@@ -116,7 +116,7 @@ def ccs2im(
     temp: float = TEMP,
     t_diff: float = T_DIFF,
 ) -> float | np.ndarray:
-    """
+    r"""
     Convert collisional cross section to reduced ion mobility.
 
     This function converts collisional cross section (CCS) values to reduced
@@ -145,17 +145,18 @@ def ccs2im(
     Notes
     -----
     The conversion uses the inverse Mason-Schamp equation:
-    1/K0 = (sqrt(μ * T) * CCS) / (18509.8632163405 * z)
 
-    Where:
-    - μ is the reduced mass
-    - T is temperature in Kelvin
-    - z is the charge
+    .. math::
+
+        \frac{1}{K_0} = \frac{\sqrt{\mu \cdot T} \cdot \Omega}{C \cdot z}
+
+    where :math:`\Omega` is the CCS, :math:`C` is a summary constant (18509.8632163405),
+    :math:`z` is the charge, :math:`\mu` is the reduced mass, and :math:`T` is the temperature
+    in Kelvin.
 
     References
     ----------
-    Adapted from theGreatHerrLebert/ionmob
-    (https://doi.org/10.1093/bioinformatics/btad486)
+    Adapted from `theGreatHerrLebert/ionmob <https://doi.org/10.1093/bioinformatics/btad486>`_.
 
     Examples
     --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,8 @@ dev = [
 docs = [
     "sphinx>=6.0",
     "numpydoc>=1.5",
-    "recommonmark>=0.7",
+    "sphinx-click",
     "sphinx-mdinclude>=0.5",
-    "toml>=0.10",
-    "semver>=2.13",
     "sphinx_rtd_theme>=1.2",
     "sphinx-autobuild>=2021.3",
 ]


### PR DESCRIPTION
Set up Sphinx with RTD theme, autodoc, sphinx-click, and intersphinx. Auto-generate API reference for public modules and CLI docs from Click decorators. Expand README installation section and use LaTeX math formatting in utils docstrings.